### PR TITLE
Skip require() of json files

### DIFF
--- a/custom.js
+++ b/custom.js
@@ -6,6 +6,8 @@ module.exports = function(env) {
   return envify
 
   function envify(file) {
+    if (/\.json$/.test(file)) return through();
+
     var buffer = ''
 
     return through(function(data) {


### PR DESCRIPTION
Envify will currently fail with an esprima parse error if used in a project where there is a `require('./somefile.json')`. This should fix it by ignoring json files entirely.
