### PR TITLE
Error in code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ var browserify = require('browserify')
   , envify = require('envify/custom')
   , fs = require('fs')
 
-var bundle = browserify('main.js')
+var b = browserify('main.js')
   , output = fs.createWriteStream('bundle.js')
 
 b.transform(envify({


### PR DESCRIPTION
There is an error in the last code example:

``` javascript
var browserify = require('browserify')
  , envify = require('envify/custom')
  , fs = require('fs')

var bundle = browserify('main.js')
  , output = fs.createWriteStream('bundle.js')

b.transform(envify({
  NODE_ENV: 'development'
}))
b.bundle().pipe(output)
```

You should use **b** insead of **bundle** variable.
