### PR TITLE
Use Recast for AST modification in custom.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "through": "~2.3.4",
-    "falafel": "~0.2.1"
+    "recast": "~0.5.6"
   },
   "keywords": [
     "environment",


### PR DESCRIPTION
The https://github.com/benjamn/recast package is similar in spirit to `falafel`, but it has more convenient tools for checking AST node types and creating new AST nodes, which helps simplify the big `if`-statement in `custom.js` and also makes it easier to create the replacement `Literal` nodes.

If that's not something you particularly care about, then feel free to close this pull request. Just thought I'd make the suggestion!
