### PR TITLE
Use jstranform instead of recast (massive speedup)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "dependencies": {
     "xtend": "~2.1.2",
     "through": "~2.3.4",
-    "recast": "~0.5.6"
+    "esprima-fb": "~3001.1.0-dev-harmony-fb",
+    "jstransform": "~3.0.0"
   },
   "keywords": [
     "environment",

--- a/visitors.js
+++ b/visitors.js
@@ -1,0 +1,32 @@
+var Syntax = require('esprima-fb').Syntax;
+var utils = require('jstransform/src/utils');
+
+function create(env) {
+
+  function visitProcessEnv(traverse, node, path, state) {
+    var key = node.property.name;
+    if (env[key] !== undefined) {
+      utils.catchup(node.range[0], state);
+      utils.append(JSON.stringify(env[key]), state);
+      utils.move(node.range[1], state);
+    }
+    return false;
+  }
+
+  visitProcessEnv.test = function(node, path, state) {
+    return (
+      node.type === Syntax.MemberExpression
+      && !node.computed
+      && node.property.type === Syntax.Identifier
+      && node.object.type === Syntax.MemberExpression
+      && node.object.object.type === Syntax.Identifier
+      && node.object.object.name === 'process'
+      && node.object.property.type === Syntax.Identifier
+      && node.object.property.name === 'env'
+    )
+  };
+
+  return [visitProcessEnv];
+}
+
+module.exports = create;


### PR DESCRIPTION
This gains us a massive speedup, envify w/ recast takes almost 7 secs on my MBA
when browserifying React codebase. While envify w/ jstransform brings this down
to 1.5 sec (pre-recast speed) and delivers the same advantages as recast
transform (preserves code formatting).
