### PR TITLE
Emit error for jstransform error

### DIFF
--- a/custom.js
+++ b/custom.js
@@ -26,7 +26,12 @@ module.exports = function(rootEnv) {
       var source = buffer.join('')
 
       if (processEnvPattern.test(source)) {
-        source = jstransform.transform(createVisitors(env), source).code
+        try {
+          source = jstransform.transform(createVisitors(env), source).code
+        }
+        catch(err) {
+          this.emit('error', err);
+        }
       }
 
       this.queue(source)


### PR DESCRIPTION
I've been using [gulp-browserify](https://github.com/deepak1556/gulp-browserify) with [gulp-plumber](https://github.com/floatdrop/gulp-plumber). Normally plumber will catch errors so gulp does not automatically crash. With envify included, everything crashes if there are errors (ex. syntax errors) since they are not emitted.
