### PR TITLE
Remove unused "xtend" dependency

### DIFF
--- a/custom.js
+++ b/custom.js
@@ -1,5 +1,4 @@
 var through = require('through')
-  , xtend = require('xtend')
   , jstransform = require('jstransform')
   , createVisitors = require('./visitors')
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "tape": "~2.3.2"
   },
   "dependencies": {
-    "xtend": "~2.1.2",
     "through": "~2.3.4",
     "esprima-fb": "^4001.3001.0-dev-harmony-fb",
     "jstransform": "^6.1.0"


### PR DESCRIPTION
Seems like after https://github.com/hughsk/envify/commit/624b03c8e750a0bb536057102d4f5b49a1eb32f6 `xtend` isn't used anymore
