### PR TITLE
Replace computed MemberExpressions w/ string literal as key

### DIFF
--- a/test.js
+++ b/test.js
@@ -7,6 +7,7 @@ test('Replaces environment variables', function(t) {
   var stream = envify({
       LOREM: 'ipsum'
     , HELLO: 'world'
+    , ZALGO: 'it comes'
   })
 
   stream()
@@ -14,11 +15,15 @@ test('Replaces environment variables', function(t) {
     .on('end', function() {
       t.notEqual(-1, buffer.indexOf('ipsum'))
       t.notEqual(-1, buffer.indexOf('world'))
+      t.notEqual(-1, buffer.indexOf('it comes'))
+      t.notEqual(-1, buffer.indexOf('process.env[ZALGO]'))
       t.end()
     })
     .end([
         'process.env.LOREM'
       , 'process.env.HELLO'
+      , 'process.env["ZALGO"]'
+      , 'process.env[ZALGO]'
     ].join('\n'))
 })
 

--- a/visitors.js
+++ b/visitors.js
@@ -6,7 +6,7 @@ function create(envs) {
   var purge = args.indexOf('purge') !== -1
 
   function visitProcessEnv(traverse, node, path, state) {
-    var key = node.property.name
+    var key = node.property.name || node.property.value
 
     for (var i = 0; i < envs.length; i++) {
       var value = envs[i][key]
@@ -32,9 +32,8 @@ function create(envs) {
   visitProcessEnv.test = function(node, path, state) {
     return (
       node.type === Syntax.MemberExpression
-      && !node.computed
       && !(path[0].type === Syntax.AssignmentExpression && path[0].left === node)
-      && node.property.type === Syntax.Identifier
+      && node.property.type === (node.computed ? Syntax.Literal : Syntax.Identifier)
       && node.object.type === Syntax.MemberExpression
       && node.object.object.type === Syntax.Identifier
       && node.object.object.name === 'process'


### PR DESCRIPTION
Cross-ref https://github.com/hughsk/envify/issues/20, ccing @yoshuawuyts

The first commit adds the requested feature. Unfortunately it causes a test to fail. The test however is broken: it is supposed to test whether `envify` ignores assignments to environment variables, but it only passed before because the test happened to use computed `MemberExpressions`. The second commit adds additional tests that show that `envify`'s previous behavior was broken.

I don't have time at the moment to fix the assignment bug, perhaps someone else can pitch in.