### PR TITLE
Update to jstransform@^10.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "through": "~2.3.4",
-    "jstransform": "^7.0.0"
+    "jstransform": "^10.0.1"
   },
   "keywords": [
     "environment",


### PR DESCRIPTION
`jstransform@^10.0.1` has an updated `esprima-fb` which includes https://github.com/facebook/esprima/pull/80. This fixes a parse error `Unexpected token =>` when arrow functions are passed as arguments.

@hughsk I don't think this change merits anything more than a minor version bump. I point this out because `React` depends on `^3.0.0`, so a major version bump would require downstream changes. https://github.com/facebook/react/blob/fa89611/npm-react/package.json#L27