### PR TITLE
Fix invalid replacement when assignment

### DIFF
--- a/test.js
+++ b/test.js
@@ -35,7 +35,9 @@ test('Ignores assignments', function(t) {
     .on('end', function() {
       t.notEqual(-1, buffer.indexOf('world'))
       t.notEqual(-1, buffer.indexOf('lorem'))
+      t.notEqual(-1, buffer.indexOf('process.env.LOREM'))
       t.notEqual(-1, buffer.indexOf('process.env["LOREM"]'))
+      t.notEqual(-1, buffer.indexOf('process.env.HELLO'))
       t.notEqual(-1, buffer.indexOf('process.env["HELLO"]'))
       t.notEqual(-1, buffer.indexOf('down'))
       t.equal(-1, buffer.indexOf('process.env.UP'))
@@ -43,7 +45,9 @@ test('Ignores assignments', function(t) {
     })
     .end([
         'process.env["LOREM"] += "lorem"'
-      , 'process.env["HELLO"]  = process.env["HELLO"] || "world"'
+      , 'process.env.LOREM += "lorem"'
+      , 'process.env["HELLO"] = process.env["HELLO"] || "world"'
+      , 'process.env.HELLO = process.env.HELLO || "world"'
       , 'process.env.UP'
     ].join('\n'))
 })

--- a/visitors.js
+++ b/visitors.js
@@ -33,6 +33,7 @@ function create(envs) {
     return (
       node.type === Syntax.MemberExpression
       && !node.computed
+      && !(path[0].type === Syntax.AssignmentExpression && path[0].left === node)
       && node.property.type === Syntax.Identifier
       && node.object.type === Syntax.MemberExpression
       && node.object.object.type === Syntax.Identifier


### PR DESCRIPTION
The tests passed before because they were testing computed `MemberExpressions`, which aren't supported. Brought up in https://github.com/hughsk/envify/pull/21.

@yoshuawuyts Can you give this a quick look before I merge + publish?
