### PR TITLE
Ignore computed object

### DIFF
--- a/test.js
+++ b/test.js
@@ -57,6 +57,27 @@ test('Ignores assignments', function(t) {
     ].join('\n'))
 })
 
+test('Ignores computed object', function(t) {
+  var buffer = ''
+  var stream = envify({
+      LOREM: 'ipsum'
+    , HELLO: 'world'
+  })
+  stream()
+    .on('data', function(d) { buffer += d })
+    .on('end', function() {
+      t.notEqual(-1, buffer.indexOf('process[env].LOREM'))
+      t.notEqual(-1, buffer.indexOf('process["env"].LOREM'))
+      t.equal(-1, buffer.indexOf('process.env.HELLO'))
+      t.end()
+    })
+    .end([
+        'process[env].LOREM'
+      , 'process["env"].LOREM'
+      , 'process.env.HELLO'
+    ].join('\n'))
+})
+
 test('Doesn\'t ignore assigning to a variable', function(t) {
   var buffer = ''
   var stream = envify({

--- a/visitors.js
+++ b/visitors.js
@@ -34,6 +34,7 @@ function create(envs) {
       node.type === Syntax.MemberExpression
       && !(path[0].type === Syntax.AssignmentExpression && path[0].left === node)
       && node.property.type === (node.computed ? Syntax.Literal : Syntax.Identifier)
+      && node.object.computed === false
       && node.object.type === Syntax.MemberExpression
       && node.object.object.type === Syntax.Identifier
       && node.object.object.name === 'process'


### PR DESCRIPTION
As in ignore `process[env]` and ignore `process['env']`. We should ignore `process[env]` because that's just wrong (this bug would not manifest itself if there aren't any `process.env` because it wouldn't match the fast-path regexp test in `custom.js`). Also, we should ignore `process['env']`, although correct, it's just too weird to support.

cc: @yoshuawuyts @hughsk 