### PR TITLE
replaceEnv can now take function as value.

### DIFF
--- a/test.js
+++ b/test.js
@@ -27,7 +27,7 @@ test('Replaces environment variables', function(t) {
     ].join('\n'))
 })
 
-test('allow functions to be pass to envify', function(t) {
+test('Allow functions to be pass to envify', function(t) {
   var buffer = '';
   var stream = envify({
     wildFunction: function() {

--- a/test.js
+++ b/test.js
@@ -27,7 +27,7 @@ test('Replaces environment variables', function(t) {
     ].join('\n'))
 })
 
-test('replaceEnv can now take functions', function(t) {
+test('allow functions to be pass to envify', function(t) {
   var buffer = '';
   var stream = envify({
     wildFunction: function() {

--- a/test.js
+++ b/test.js
@@ -27,6 +27,24 @@ test('Replaces environment variables', function(t) {
     ].join('\n'))
 })
 
+test('replaceEnv can now take functions', function(t) {
+  var buffer = '';
+  var stream = envify({
+    wildFunction: function() {
+      return 1+1;
+    }
+  });
+  stream()
+    .on('data', function(d) { buffer += d })
+    .on('end', function() {
+      t.notEqual(-1,buffer.indexOf('function'));
+      t.end();
+    })
+    .end([
+        'process.env.wildFunction'
+    ].join('\n'));
+});
+
 test('Ignores assignments', function(t) {
   var buffer = ''
   var stream = envify({

--- a/visitors.js
+++ b/visitors.js
@@ -25,7 +25,12 @@ function create(envs) {
 
   function replaceEnv(node, state, value) {
     utils.catchup(node.range[0], state)
-    utils.append(JSON.stringify(value), state)
+    if (typeof value === 'function') {
+      utils.append(value, state)
+    }
+    else {
+      utils.append(JSON.stringify(value), state)
+    }
     utils.move(node.range[1], state)
   }
 

--- a/visitors.js
+++ b/visitors.js
@@ -24,14 +24,14 @@ function create(envs) {
   }
 
   function replaceEnv(node, state, value) {
-    utils.catchup(node.range[0], state)
+    utils.catchup(node.range[0], state);
     if (typeof value === 'function') {
-      utils.append(value, state)
+      utils.append(value, state);
     }
     else {
-      utils.append(JSON.stringify(value), state)
+      utils.append(JSON.stringify(value), state);
     }
-    utils.move(node.range[1], state)
+    utils.move(node.range[1], state);
   }
 
   visitProcessEnv.test = function(node, path, state) {


### PR DESCRIPTION
I use envify to send my configs and some of them are functions. The `JSON.stringify(value)` return undefined when value is a function.