### PR TITLE
Upgrade esprima to v4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "tape": "^4.6.0"
   },
   "dependencies": {
-    "esprima": "~3.1.0",
+    "esprima": "^4.0.0",
     "through": "~2.3.4"
   },
   "keywords": [


### PR DESCRIPTION
Adds support for latest EcmaScript features that are available in modern browsers, such as async/await.

Related: substack/node-browserify#1667 (though they use acorn)