### PR TITLE
Add support for dotenv

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+MESSAGE_FROM_DOTENV=Hello, World!

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 test.js
 .travis.yml
+.env

--- a/README.md
+++ b/README.md
@@ -135,6 +135,27 @@ b.transform(envify({
 }))
 ```
 
+## Loading `.env` file ##
+
+Envify can load a `.env` file for you using the
+[dotenv](https://github.com/motdotla/dotenv) package. To enable this
+functionallity, simply use the subarg syntax and include `dotenv` after
+`envify`, e.g.:
+
+``` bash
+browserify index.js -t [ envify dotenv --NODE_ENV development ]
+```
+
+Or if you're using the module API, you can pass `_: "dotenv"` into your
+arguments like so:
+
+``` javascript
+b.transform(envify({
+    _: 'dotenv'
+  , NODE_ENV: 'development'
+}))
+```
+
 ## Contributors ##
 
 * [hughsk](http://github.com/hughsk)

--- a/custom.js
+++ b/custom.js
@@ -8,7 +8,15 @@ var processEnvPattern = /\bprocess\.env\b/
 var dotenvCache
 function getDotenv() {
   if (dotenvCache === undefined) {
-    dotenvCache = dotenv.parse(fs.readFileSync('.env'))
+    try {
+      dotenvCache = dotenv.parse(fs.readFileSync('.env'))
+    } catch (err) {
+      if (err.code === 'ENOENT') {
+        dotenvCache = {}
+      } else {
+        throw err
+      }
+    }
   }
 
   return dotenvCache

--- a/custom.js
+++ b/custom.js
@@ -1,7 +1,18 @@
-var esprima = require('esprima')
+var dotenv = require('dotenv')
+  , esprima = require('esprima')
+  , fs = require('fs')
   , through = require('through')
 
 var processEnvPattern = /\bprocess\.env\b/
+
+var dotenvCache
+function getDotenv() {
+  if (dotenvCache === undefined) {
+    dotenvCache = dotenv.parse(fs.readFileSync('.env'))
+  }
+
+  return dotenvCache
+}
 
 module.exports = function(rootEnv) {
   rootEnv = rootEnv || process.env || {}
@@ -23,6 +34,10 @@ module.exports = function(rootEnv) {
       var args  = [].concat(envs[0]._ || []).concat(envs[1]._ || [])
       var purge = args.indexOf('purge') !== -1
       var replacements = []
+
+      if (args.indexOf('dotenv') !== -1) {
+        envs.push(getDotenv())
+      }
 
       function match(node) {
         return (

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "tape": "^4.6.0"
   },
   "dependencies": {
+    "dotenv": "^4.0.0",
     "esprima": "^4.0.0",
     "through": "~2.3.4"
   },

--- a/test.js
+++ b/test.js
@@ -183,3 +183,29 @@ test('-t [ envify purge --argument ]', function(t) {
       , 'var y = process.env.argument'
     ].join('\n'))
 })
+
+test('-t [ envify dotenv ]', function(t) {
+  var stream = envify({ argument: 'not purged' })
+  var buffer = ''
+
+  stream(__filename, { _: ['dotenv'] })
+    .on('data', function(d) { buffer += d })
+    .on('end', function() {
+      t.notEqual(-1, buffer.indexOf('var x = "Hello, World!"'), 'replaces with value from dotenv file')
+      t.end()
+    })
+    .end('var x = process.env.MESSAGE_FROM_DOTENV')
+})
+
+test('-t [ envify dotenv --MESSAGE_FROM_DOTENV intercepted ]', function(t) {
+  var stream = envify({ argument: 'not purged' })
+  var buffer = ''
+
+  stream(__filename, { _: ['dotenv'], MESSAGE_FROM_DOTENV: 'intercepted' })
+    .on('data', function(d) { buffer += d })
+    .on('end', function() {
+      t.notEqual(-1, buffer.indexOf('var x = "intercepted"'), 'uses arguments before dotenv file')
+      t.end()
+    })
+    .end('var x = process.env.MESSAGE_FROM_DOTENV')
+})


### PR DESCRIPTION
This PR adds support for loading a [`.env` (dotenv)](https://github.com/motdotla/dotenv) file containing additional environmental variables. It's super useful when you have multiple projects since it allows you to keep your environment contained to each project instead of having it global.

The file will only be loaded when the `dotenv` flag is passed, and variables from the file will only be used if they aren't already specified elsewhere which is how the dotenv package usually works when loading it straight into process.env.

I tried to follow the existing code style, please let me know if you need anything more. Thanks 👋 